### PR TITLE
make device specific code to be device agnostic, to better support more accelerators

### DIFF
--- a/apollo_torch/adamw8bit.py
+++ b/apollo_torch/adamw8bit.py
@@ -24,6 +24,9 @@ class AdamW8bit(Optimizer2State):
 
         overflows = []
 
+        device_type = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
+        torch_accelerator_module = getattr(torch, device_type)
+
         if not self.initialized:
             self.check_overrides()
             self.to_gpu()  # needed for fairseq pure fp16 training
@@ -62,7 +65,7 @@ class AdamW8bit(Optimizer2State):
 
                 self.prefetch_state(p)
                 self.update_step(group, p, gindex, pindex)
-                torch.cuda.synchronize()
+                torch_accelerator_module.synchronize()
                 
                 # GaLore Projection Back
                 if "rank" in group:
@@ -77,7 +80,7 @@ class AdamW8bit(Optimizer2State):
         if self.is_paged:
             # all paged operation are asynchronous, we need
             # to sync to make sure all tensors are in the right state
-            torch.cuda.synchronize()
+            torch_accelerator_module.synchronize()
 
 
         return loss

--- a/utils/argparse.py
+++ b/utils/argparse.py
@@ -9,7 +9,7 @@ def parse_args(args):
 
     device_type = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
     torch_accelerator_module = getattr(torch, device_type)
-    bf16_supported = torch_accelerator_module.is_bf16_supported()
+    bf16_supported = torch_accelerator_module.is_bf16_supported() if hasattr(torch_accelerator_module, 'is_bf16_supported') else False
 
     ### Experiment setup ###
     parser.add_argument("--model_config", type=str, required=True)

--- a/utils/argparse.py
+++ b/utils/argparse.py
@@ -7,12 +7,15 @@ from datetime import datetime
 def parse_args(args):
     parser = argparse.ArgumentParser()
 
+    device_type = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
+    torch_accelerator_module = getattr(torch, device_type)
+    bf16_supported = torch_accelerator_module.is_bf16_supported()
 
     ### Experiment setup ###
     parser.add_argument("--model_config", type=str, required=True)
     parser.add_argument("--eval_every", type=int, default=5_000)
     parser.add_argument("--save_every", type=int, default=10_000)
-    parser.add_argument("--dtype", type=str, default="bfloat16" if torch.cuda.is_bf16_supported() else "float32")
+    parser.add_argument("--dtype", type=str, default="bfloat16" if bf16_supported else "float32")
     parser.add_argument("--seed", type=int, default=0)
 
     parser.add_argument("--resume_step", type=int, default=None) # if None, resume from the latest checkpoint

--- a/utils/fake_quantization.py
+++ b/utils/fake_quantization.py
@@ -26,7 +26,6 @@ def _quantize_tensor(w, q_group_size=-1, n_bit=8):
     assert torch.isnan(scales).sum() == 0
     assert torch.isnan(w).sum() == 0
 
-    print(f"{w.device.type}")
     w = torch.clamp(torch.round(w / scales) + zeros, min_int, max_int)
     w = w.reshape(org_w_shape).to(torch.uint8)
 

--- a/utils/quantization.py
+++ b/utils/quantization.py
@@ -156,7 +156,7 @@ if __name__ == '__main__':
     print('Time for FW+BW = {:.2f} s'.format(end-start))
     print('------------------------------------')
 
-    device_0 = f'{device_type}:1'
+    device_1 = f'{device_type}:1'
     int8_linear1 = QScaleLinear(fp16_linear1.weight, None, device=device_1, num_bits=8, group_size=GROUP_SIZE)
     print('after initial weight for int8', '{:.2f} MB'.format(torch_accelerator_module.memory_allocated(device_1)//1024/1024))
     mem_weight_int = torch_accelerator_module.memory_allocated(device_1)//1024/1024

--- a/utils/quantization.py
+++ b/utils/quantization.py
@@ -95,7 +95,7 @@ class QScaleLinear(nn.Module):
         if device is None:
             device_type = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
         else:
-            device_type = torch.Device(device).device_type
+            device_type = torch.device(device).type
         torch_accelerator_module = getattr(torch, device_type)
 
         int8_weight, scales, zeros = _quantize_tensor_int8(weight.data, q_group_size=group_size)

--- a/utils/quantization.py
+++ b/utils/quantization.py
@@ -99,7 +99,8 @@ class QScaleLinear(nn.Module):
         torch_accelerator_module = getattr(torch, device_type)
 
         int8_weight, scales, zeros = _quantize_tensor_int8(weight.data, q_group_size=group_size)
-        torch_accelerator_module.empty_cache()
+        if hasattr(torch_accelerator_module, 'empty_cache'):
+            torch_accelerator_module.empty_cache()
 
         self.weight = Parameter(int8_weight, requires_grad=False).to(device) # Only Tensors of floating point and complex dtype can require gradients, using float_gradient to store the gradient
         

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -37,7 +37,7 @@ def set_seed(args):
     if hasattr(torch_accelerator_module, "manual_seed_all"):
         torch_accelerator_module.manual_seed_all(args.seed)
 
-    torch.use_deterministic_algorithms()
+    torch.use_deterministic_algorithms(True)
 
     # Ensure deterministic behavior in cuDNN
     if torch.cuda.is_available():

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -31,12 +31,17 @@ def set_seed(args):
     np.random.seed(args.seed)
     random.seed(args.seed)
 
-    # Set seed for all GPUs
-    torch.cuda.manual_seed_all(args.seed)
+    # Set seed for all accelerators
+    device_type = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
+    torch_accelerator_module = getattr(torch, device_type)
+    torch_accelerator_module.manual_seed_all(args.seed)
+
+    torch.use_deterministic_algorithms()
 
     # Ensure deterministic behavior in cuDNN
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+    if torch.cuda.is_available():
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
 
 
 def setup_model(args):

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -34,7 +34,8 @@ def set_seed(args):
     # Set seed for all accelerators
     device_type = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
     torch_accelerator_module = getattr(torch, device_type)
-    torch_accelerator_module.manual_seed_all(args.seed)
+    if hasattr(torch_accelerator_module, "manual_seed_all"):
+        torch_accelerator_module.manual_seed_all(args.seed)
 
     torch.use_deterministic_algorithms()
 


### PR DESCRIPTION
Since PyTorch 2.6, [torch.accelerator](https://docs.pytorch.org/docs/2.6/accelerator.html#module-torch.accelerator) was introduced to support more accelerators beyond CUDA, like Intel XPU etc. Based on it, I update the code to use `torch.accelerator` to make APOLLO can run in other devices besides CUDA. Tested on Intel XPU, and it works.

For older PyTorch versions which doesn't have `torch.accelerator` API, it will still call `torch.cuda` as original code, so, it's backward compatible.

@zhuhanqing , pls help review, thx very much.